### PR TITLE
Fix oversized HeroIcons and improve UI layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,8 +21,8 @@ export default function RootLayout({
         <div className="flex min-h-screen">
           <Sidebar />
           <div className="flex flex-col md:pl-64 flex-1">
-            <main className="flex-1 p-6">
-              <div className="max-w-7xl mx-auto">
+            <main className="flex-1 p-4">
+              <div className="max-w-6xl mx-auto">
                 {children}
               </div>
             </main>

--- a/app/notes/[id]/edit/page.tsx
+++ b/app/notes/[id]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
+import { XCircleIcon } from '@heroicons/react/24/solid'
 import NoteForm from '@/components/notes/NoteForm'
 import { fetchWithAuth } from '@/lib/utils/apiUtils'
 
@@ -67,9 +68,11 @@ export default function EditNotePage() {
       <div className="bg-red-50 border-l-4 border-red-400 p-4">
         <div className="flex">
           <div className="flex-shrink-0">
-            <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-            </svg>
+            <XCircleIcon 
+              className="text-red-400" 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
           </div>
           <div className="ml-3">
             <p className="text-sm text-red-700">{error || 'Note not found'}</p>

--- a/app/notes/[id]/page.tsx
+++ b/app/notes/[id]/page.tsx
@@ -4,6 +4,12 @@ import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
+import { 
+  XCircleIcon, 
+  ArrowLeftIcon, 
+  PencilIcon, 
+  TrashIcon 
+} from '@heroicons/react/24/solid'
 import { formatDistanceToNow } from '@/lib/utils/dateUtils'
 import { fetchWithAuth } from '@/lib/utils/apiUtils'
 
@@ -94,9 +100,11 @@ export default function NoteDetailPage() {
       <div className="bg-red-50 border-l-4 border-red-400 p-4">
         <div className="flex">
           <div className="flex-shrink-0">
-            <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-            </svg>
+            <XCircleIcon 
+              className="text-red-400" 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
           </div>
           <div className="ml-3">
             <p className="text-sm text-red-700">{error || 'Note not found'}</p>
@@ -118,9 +126,11 @@ export default function NoteDetailPage() {
             href="/notes" 
             className="text-primary-600 hover:text-primary-800 flex items-center mb-2"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd" />
-            </svg>
+            <ArrowLeftIcon 
+              className="mr-1" 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
             Back to Notes
           </Link>
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{note.title}</h1>
@@ -131,9 +141,11 @@ export default function NoteDetailPage() {
             href={`/notes/${note.id}/edit`}
             className="btn btn-secondary flex items-center"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-            </svg>
+            <PencilIcon 
+              className="mr-1" 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
             Edit
           </Link>
           
@@ -142,9 +154,11 @@ export default function NoteDetailPage() {
             disabled={isDeleting}
             className="btn bg-red-600 text-white hover:bg-red-700 flex items-center"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-            </svg>
+            <TrashIcon 
+              className="mr-1" 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
             {isDeleting ? 'Deleting...' : 'Delete'}
           </button>
         </div>

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { XCircleIcon, DocumentIcon } from '@heroicons/react/24/solid'
 import NoteCard from '@/components/notes/NoteCard'
 import { fetchWithAuth } from '@/lib/utils/apiUtils'
 
@@ -61,8 +62,8 @@ export default function NotesPage() {
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">All Notes</h1>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">All Notes</h1>
         <Link
           href="/notes/new"
           className="btn btn-primary"
@@ -79,9 +80,11 @@ export default function NotesPage() {
         <div className="bg-red-50 border-l-4 border-red-400 p-4 mb-6">
           <div className="flex">
             <div className="flex-shrink-0">
-              <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-              </svg>
+              <XCircleIcon 
+                className="text-red-400" 
+                style={{ width: '20px', height: '20px' }} 
+                aria-hidden="true" 
+              />
             </div>
             <div className="ml-3">
               <p className="text-sm text-red-700">{error}</p>
@@ -90,9 +93,11 @@ export default function NotesPage() {
         </div>
       ) : notes.length === 0 ? (
         <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow">
-          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
+          <DocumentIcon 
+            className="mx-auto text-gray-400" 
+            style={{ width: '48px', height: '48px' }} 
+            aria-hidden="true" 
+          />
           <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">No notes yet</h3>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">Create your first note to get started.</p>
           <div className="mt-6">
@@ -102,7 +107,7 @@ export default function NotesPage() {
           </div>
         </div>
       ) : (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {notes.map(note => (
             <NoteCard 
               key={note.id} 

--- a/app/tags/[id]/page.tsx
+++ b/app/tags/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
+import { XCircleIcon, ArrowLeftIcon, DocumentIcon } from '@heroicons/react/24/solid'
 import NoteCard from '@/components/notes/NoteCard'
 import { fetchWithAuth } from '@/lib/utils/apiUtils'
 
@@ -84,9 +85,11 @@ export default function TagDetailPage() {
       <div className="bg-red-50 border-l-4 border-red-400 p-4">
         <div className="flex">
           <div className="flex-shrink-0">
-            <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-            </svg>
+            <XCircleIcon 
+              className="text-red-400" 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
           </div>
           <div className="ml-3">
             <p className="text-sm text-red-700">{error || 'Tag not found'}</p>
@@ -104,9 +107,11 @@ export default function TagDetailPage() {
             href="/tags" 
             className="text-primary-600 hover:text-primary-800 flex items-center mb-2"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd" />
-            </svg>
+            <ArrowLeftIcon 
+              className="mr-1" 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
             Back to Tags
           </Link>
           <div className="flex items-center">
@@ -128,9 +133,11 @@ export default function TagDetailPage() {
         
         {notes.length === 0 ? (
           <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow">
-            <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
+            <DocumentIcon 
+              className="mx-auto text-gray-400" 
+              style={{ width: '48px', height: '48px' }} 
+              aria-hidden="true" 
+            />
             <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">No notes with this tag</h3>
             <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
               Create a new note and add this tag to it.

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { XCircleIcon, TagIcon, TrashIcon } from '@heroicons/react/24/solid'
 import { fetchWithAuth } from '@/lib/utils/apiUtils'
 
 type Tag = {
@@ -63,8 +64,8 @@ export default function TagsPage() {
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">All Tags</h1>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-xl font-bold text-gray-900 dark:text-white">All Tags</h1>
       </div>
       
       {loading ? (
@@ -75,9 +76,11 @@ export default function TagsPage() {
         <div className="bg-red-50 border-l-4 border-red-400 p-4 mb-6">
           <div className="flex">
             <div className="flex-shrink-0">
-              <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-              </svg>
+              <XCircleIcon 
+                className="text-red-400" 
+                style={{ width: '20px', height: '20px' }} 
+                aria-hidden="true" 
+              />
             </div>
             <div className="ml-3">
               <p className="text-sm text-red-700">{error}</p>
@@ -86,9 +89,11 @@ export default function TagsPage() {
         </div>
       ) : tags.length === 0 ? (
         <div className="text-center py-12 bg-white dark:bg-gray-800 rounded-lg shadow">
-          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
-          </svg>
+          <TagIcon 
+            className="mx-auto text-gray-400" 
+            style={{ width: '48px', height: '48px' }} 
+            aria-hidden="true" 
+          />
           <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">No tags yet</h3>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Tags will appear here when you add them to your notes.
@@ -99,7 +104,7 @@ export default function TagsPage() {
           {tags.map(tag => (
             <div
               key={tag.id}
-              className="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden flex flex-col"
+              className="bg-white dark:bg-gray-800 shadow-sm rounded-lg overflow-hidden flex flex-col"
             >
               <div className="flex-1 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
                 <Link 
@@ -110,7 +115,7 @@ export default function TagsPage() {
                     className="w-4 h-4 rounded-full mr-2"
                     style={{ backgroundColor: tag.color }}
                   />
-                  <h3 className="text-lg font-medium text-gray-900 dark:text-white hover:text-primary-600 dark:hover:text-primary-400">
+                  <h3 className="text-base font-medium text-gray-900 dark:text-white hover:text-primary-600 dark:hover:text-primary-400">
                     {tag.name}
                   </h3>
                 </Link>
@@ -120,9 +125,10 @@ export default function TagsPage() {
                   onClick={() => handleDeleteTag(tag.id)}
                   className="text-red-600 hover:text-red-800"
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-                  </svg>
+                  <TrashIcon 
+                    style={{ width: '20px', height: '20px' }} 
+                    aria-hidden="true" 
+                  />
                 </button>
               </div>
             </div>

--- a/components/home/HomeClient.tsx
+++ b/components/home/HomeClient.tsx
@@ -38,9 +38,9 @@ export default function HomeClient() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[80vh]">
-      <h1 className="text-4xl font-bold mb-4">Welcome to Insight Ink</h1>
-      <p className="text-xl mb-8">An AI-powered note-taking application</p>
+    <div className="flex flex-col items-center justify-center min-h-[70vh]">
+      <h1 className="text-3xl font-bold mb-3">Welcome to Insight Ink</h1>
+      <p className="text-lg mb-6">An AI-powered note-taking application</p>
       
       <div className="flex gap-4 mb-8">
         <a 

--- a/components/notes/NoteCard.tsx
+++ b/components/notes/NoteCard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { PencilIcon, TrashIcon } from '@heroicons/react/24/solid'
 import { formatDistanceToNow } from '@/lib/utils/dateUtils'
 import { fetchWithAuth } from '@/lib/utils/apiUtils'
 
@@ -63,10 +64,10 @@ export default function NoteCard({ note, onDelete }: NoteCardProps) {
   }
   
   return (
-    <div className="card hover:shadow-lg transition-shadow duration-200">
+    <div className="card hover:shadow-md transition-shadow duration-200">
       <div className="flex justify-between items-start">
         <Link href={`/notes/${note.id}`} className="flex-1">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white hover:text-primary-600 dark:hover:text-primary-400">
+          <h3 className="text-base font-semibold text-gray-900 dark:text-white hover:text-primary-600 dark:hover:text-primary-400">
             {note.title}
           </h3>
         </Link>
@@ -77,9 +78,10 @@ export default function NoteCard({ note, onDelete }: NoteCardProps) {
             className="p-1 text-gray-500 hover:text-primary-600"
           >
             <span className="sr-only">Edit</span>
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-              <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-            </svg>
+            <PencilIcon 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
           </Link>
           
           <button
@@ -88,9 +90,10 @@ export default function NoteCard({ note, onDelete }: NoteCardProps) {
             className="p-1 text-gray-500 hover:text-red-600"
           >
             <span className="sr-only">Delete</span>
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
-            </svg>
+            <TrashIcon 
+              style={{ width: '20px', height: '20px' }} 
+              aria-hidden="true" 
+            />
           </button>
         </div>
       </div>

--- a/components/notes/NoteForm.tsx
+++ b/components/notes/NoteForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { XCircleIcon } from '@heroicons/react/24/solid'
 import { fetchWithAuth } from '@/lib/utils/apiUtils'
 
 type Tag = {
@@ -163,9 +164,11 @@ export default function NoteForm({
         <div className="bg-red-50 border-l-4 border-red-400 p-4">
           <div className="flex">
             <div className="flex-shrink-0">
-              <svg className="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-              </svg>
+              <XCircleIcon 
+                className="text-red-400" 
+                style={{ width: '20px', height: '20px' }} 
+                aria-hidden="true" 
+              />
             </div>
             <div className="ml-3">
               <p className="text-sm text-red-700">{error}</p>
@@ -232,8 +235,8 @@ export default function NoteForm({
         <div className="relative">
           <textarea
             id="content"
-            rows={20}
-            className="input font-mono"
+            rows={15}
+            className="input font-mono text-sm"
             placeholder="# Markdown supported
 
 Write your notes using **markdown** formatting..."

--- a/components/ui/Sidebar.tsx
+++ b/components/ui/Sidebar.tsx
@@ -34,7 +34,8 @@ export default function Sidebar() {
                   } group flex items-center px-2 py-2 text-sm font-medium rounded-md`}
                 >
                   <item.icon
-                    className="mr-3 flex-shrink-0 h-6 w-6 text-primary-300"
+                    className="mr-3 flex-shrink-0 text-primary-300"
+                    style={{ width: '20px', height: '20px' }}
                     aria-hidden="true"
                   />
                   {item.name}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,7 +15,7 @@
 
 @layer components {
   .btn {
-    @apply px-4 py-2 rounded font-medium transition-colors;
+    @apply px-3 py-1.5 rounded font-medium transition-colors text-sm;
   }
 
   .btn-primary {
@@ -27,7 +27,7 @@
   }
 
   .card {
-    @apply bg-white dark:bg-gray-800 rounded-lg shadow-md p-6;
+    @apply bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4;
   }
 
   .input {


### PR DESCRIPTION
## Changes

### Icon Sizing Fix
- Replace Tailwind h-5 w-5 classes with explicit inline styles
- Set consistent icon sizes: 20px for regular icons, 48px for empty state icons
- Apply fix across all components using HeroIcons
- Ensures proper icon sizing regardless of CSS class conflicts

### UI Layout Improvements
- Reduce padding and max-width in main layout for better space utilization
- Adjust HomeClient component sizing for better proportions
- Update button and card styles in globals.css for consistent sizing

## Testing
- Verified icon sizing is consistent across all components
- Confirmed UI layout improvements maintain proper spacing and alignment